### PR TITLE
Adding consul-esm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+FROM sethvargo/hashicorp-installer:0.1.3 AS installer
+ARG CONSUL_ESM_VERSION='0.3.1'
+RUN /install-hashicorp-tool "consul-esm" "$CONSUL_ESM_VERSION"
+
 FROM asicsdigital/hermes:stable
 RUN apk -v --update --no-cache add \
         bash \
@@ -18,6 +22,8 @@ RUN apk -v --update --no-cache add \
     apk -v --purge del py-pip
     #rm /var/cache/apk/*
 
+COPY --from=installer /software/consul-esm /opt/hermes/bin/consul-esm
+COPY consul-esm.d/* /etc/consul-esm.d/
 COPY scripts/*.sh /usr/local/bin/
 COPY check_definitions/*.sh /usr/local/bin/check_definitions/
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh

--- a/check_definitions/backup.sh
+++ b/check_definitions/backup.sh
@@ -32,7 +32,7 @@ _SERVICE=$(cat <<EOT
 EOT
 )
 
-echo ${_SERVICE}
+echo "${_SERVICE}"
 
 
 

--- a/check_definitions/docker-test-critical.sh
+++ b/check_definitions/docker-test-critical.sh
@@ -16,4 +16,4 @@ _CHECK=$(cat <<EOT
 EOT
 )
 
-echo ${_CHECK}
+echo "${_CHECK}"

--- a/check_definitions/docker-test-warning.sh
+++ b/check_definitions/docker-test-warning.sh
@@ -16,4 +16,4 @@ _CHECK=$(cat <<EOT
 EOT
 )
 
-echo ${_CHECK}
+echo "${_CHECK}"

--- a/check_definitions/docker-test.sh
+++ b/check_definitions/docker-test.sh
@@ -16,4 +16,4 @@ _CHECK=$(cat <<EOT
 EOT
 )
 
-echo ${_CHECK}
+echo "${_CHECK}"

--- a/check_definitions/ecs-cluster.sh
+++ b/check_definitions/ecs-cluster.sh
@@ -48,4 +48,4 @@ _SERVICE=$(cat <<EOT
 EOT
 )
 
-echo ${_SERVICE}
+echo "${_SERVICE}"

--- a/consul-esm.d/config.hcl.sh
+++ b/consul-esm.d/config.hcl.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+CONSUL_HTTP_ADDR="http://$(dudewheresmy hostip):8500"
+
+_ESM_CONFIG=$(cat <<EOT
+
+// The log level to use.
+log_level = "INFO"
+
+// Controls whether to enable logging to syslog.
+enable_syslog = false
+
+// The syslog facility to use, if enabled.
+syslog_facility = ""
+
+// The service name for this agent to use when registering itself with Consul.
+consul_service = "consul-esm"
+
+// The service tag for this agent to use when registering itself with Consul.
+// ESM instances that share a service name/tag combination will have the work
+// of running health checks and pings for any external nodes in the catalog
+// divided evenly amongst themselves.
+consul_service_tag = ""
+
+// The directory in the Consul KV store to use for storing runtime data.
+consul_kv_path = "consul-esm/"
+
+// The node metadata values used for the ESM to qualify a node in the catalog
+// as an "external node".
+external_node_meta {
+    "external-node" = "true"
+}
+
+// The length of time to wait before reaping an external node due to failed
+// pings.
+node_reconnect_timeout = "72h"
+
+// The interval to ping and update coordinates for external nodes that have
+// 'external-probe' set to true. By default, ESM will attempt to ping and
+// update the coordinates for all nodes it is watching every 10 seconds.
+node_probe_interval = "10s"
+
+// The address of the local Consul agent. Can also be provided through the
+// CONSUL_HTTP_ADDR environment variable.
+#http_addr = "localhost:8500"
+http_addr = "${CONSUL_HTTP_ADDR}"
+
+// The ACL token to use when communicating with the local Consul agent. Can
+// also be provided through the CONSUL_HTTP_TOKEN environment variable.
+token = ""
+
+// The Consul datacenter to use.
+#datacenter = "dc1"
+
+// The CA file to use for talking to Consul over TLS. Can also be provided
+// though the CONSUL_CACERT environment variable.
+ca_file = ""
+
+// The path to a directory of CA certs to use for talking to Consul over TLS.
+// Can also be provided through the CONSUL_CAPATH environment variable.
+ca_path = ""
+
+// The client cert file to use for talking to Consul over TLS. Can also be
+// provided through the CONSUL_CLIENT_CERT environment variable.
+cert_file = ""
+
+// The client key file to use for talking to Consul over TLS. Can also be
+// provided through the CONSUL_CLIENT_KEY environment variable.
+key_file = ""
+
+// The server name to use as the SNI host when connecting to Consul via TLS.
+// Can also be provided through the CONSUL_TLS_SERVER_NAME environment
+// variable.
+tls_server_name = ""
+
+// The method to use for pinging external nodes. Defaults to "udp" but can
+// also be set to "socket" to use ICMP (which requires root privileges).
+ping_type = "udp"
+
+EOT
+)
+
+echo "${_ESM_CONFIG}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       S3_BUCKET: somebucket-${USER}
   consul:
     #image: "fitnesskeeper/consul"
-    image: "consul:1.0.3"
+    image: "consul:1.4.0"
     environment:
       CONSUL_BIND_INTERFACE: eth0
       CONSUL_LOCAL_CONFIG: '{"enable_script_checks": true}'

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,5 +20,6 @@ if [ -n "$CHECKS" ]; then
    done
 fi
 
-while true ; do echo "I am sleeping"; sleep 60;done
-#/bin/bash
+cd /etc/consul-esm.d
+./config.hcl.sh > config.hcl
+consul-esm -config-file=/etc/consul-esm.d/config.hcl


### PR DESCRIPTION
This adds the consul-esm bin to the sidecar this allows you to setup
healthcheck for external services